### PR TITLE
feeds piece randomizer a list from initBoard props

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,11 @@ import './App.css';
 import {
     Header,
     Tetris
-} from './components'
+} from './components';
+
+import {
+    initBoard
+} from './components/Tetris/useTetrisHooks';
 
 function App() {
 return (
@@ -12,7 +16,7 @@ return (
 <div className='centered_cont'>
 
     <Header />
-    <Tetris />
+    <Tetris initBoard={initBoard} />
 
 </div>
 </div>

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import {
 } from './components';
 
 import {
-    initBoard
+    initBoard, gamePcs
 } from './components/Tetris/useTetrisHooks';
 
 function App() {
@@ -16,7 +16,7 @@ return (
 <div className='centered_cont'>
 
     <Header />
-    <Tetris initBoard={initBoard} />
+    <Tetris initBoard={initBoard(gamePcs)} />
 
 </div>
 </div>

--- a/src/components/Tetris/Tetris.js
+++ b/src/components/Tetris/Tetris.js
@@ -18,7 +18,7 @@ import { clearLines } from './assets/clearLines.js';
 // tetris state assets
 import {
     useTetris,
-    initBoard,
+    // initBoard,
     BOARD_ACTIONS,
     boardReducer,
 } from './useTetrisHooks';
@@ -39,7 +39,7 @@ const lineActions = {
     'update': BOARD_ACTIONS.UPDATE,
 };
 
-function Tetris() {
+function Tetris({ initBoard }) {
 
     const startGameButtonBlurRef = useRef();
     const killActiveButtonBlurRef = useRef();

--- a/src/components/Tetris/__tests__/Tetris[access].test.js
+++ b/src/components/Tetris/__tests__/Tetris[access].test.js
@@ -4,9 +4,10 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 
 import Tetris from '../Tetris';
+import { initBoard } from '../useTetrisHooks';
 
 beforeEach(() => {
-    render(<Tetris />);
+    render(<Tetris initBoard={initBoard} />);
 });
 
 test('it renders Tetris component', () => {

--- a/src/components/Tetris/__tests__/Tetris[access].test.js
+++ b/src/components/Tetris/__tests__/Tetris[access].test.js
@@ -4,10 +4,10 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 
 import Tetris from '../Tetris';
-import { initBoard } from '../useTetrisHooks';
+import { initBoard, gamePcs } from '../useTetrisHooks';
 
 beforeEach(() => {
-    render(<Tetris initBoard={initBoard} />);
+    render(<Tetris initBoard={initBoard(gamePcs)} />);
 });
 
 test('it renders Tetris component', () => {

--- a/src/components/Tetris/__tests__/Tetris[movementCollision].test.js
+++ b/src/components/Tetris/__tests__/Tetris[movementCollision].test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
+import { initBoard } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -12,7 +13,7 @@ let dom_tetrisCont;
 
 beforeEach(() => {
 
-    render(<Tetris />);
+    render(<Tetris initBoard={initBoard} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/__tests__/Tetris[movementCollision].test.js
+++ b/src/components/Tetris/__tests__/Tetris[movementCollision].test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
-import { initBoard } from '../useTetrisHooks';
+import { initBoard, gamePcs } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -13,7 +13,7 @@ let dom_tetrisCont;
 
 beforeEach(() => {
 
-    render(<Tetris initBoard={initBoard} />);
+    render(<Tetris initBoard={initBoard(gamePcs)} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/__tests__/Tetris[movement].test.js
+++ b/src/components/Tetris/__tests__/Tetris[movement].test.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
+import { initBoard } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -16,7 +17,7 @@ let dom_tetrisCont;
 beforeEach(() => {
     prefireCoords = [];
 
-    render(<Tetris />);
+    render(<Tetris initBoard={initBoard} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/__tests__/Tetris[movement].test.js
+++ b/src/components/Tetris/__tests__/Tetris[movement].test.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
-import { initBoard } from '../useTetrisHooks';
+import { initBoard, gamePcs } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -17,7 +17,7 @@ let dom_tetrisCont;
 beforeEach(() => {
     prefireCoords = [];
 
-    render(<Tetris initBoard={initBoard} />);
+    render(<Tetris initBoard={initBoard(gamePcs)} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/__tests__/Tetris[rotate].test.js
+++ b/src/components/Tetris/__tests__/Tetris[rotate].test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { screen, render, fireEvent } from '@testing-library/react';
+
+import Tetris from '../Tetris';
+import { getPcs } from '../../../helpers/spec/getPcs';
+
+import { initBoard, dummyPcs } from '../useTetrisHooks';
+
+beforeEach(() => {
+    render(<Tetris initBoard={initBoard(dummyPcs)} />);
+});
+
+test('it renders dummy pc', () => {
+    const dom_tetris = screen.getByTestId('tetris_cont');
+
+    const renderedPc = getPcs(dom_tetris);
+
+    console.log(renderedPc);
+});

--- a/src/components/Tetris/__tests__/Tetris[transformActive].test.js
+++ b/src/components/Tetris/__tests__/Tetris[transformActive].test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
-import { initBoard } from '../useTetrisHooks';
+import { initBoard, gamePcs } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -12,7 +12,7 @@ let dom_tetrisCont;
 let dom_downCtrl;
 
 beforeEach(() => {
-    render(<Tetris initBoard={initBoard} />);
+    render(<Tetris initBoard={initBoard(gamePcs)} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/__tests__/Tetris[transformActive].test.js
+++ b/src/components/Tetris/__tests__/Tetris[transformActive].test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import Tetris from '../Tetris';
+import { initBoard } from '../useTetrisHooks';
 
 import { getPcs } from '../../../helpers/spec/getPcs';
 
@@ -11,7 +12,7 @@ let dom_tetrisCont;
 let dom_downCtrl;
 
 beforeEach(() => {
-    render(<Tetris />);
+    render(<Tetris initBoard={initBoard} />);
 
     const dom_startGame = screen.getByTestId('startGame');
     fireEvent.click(dom_startGame);

--- a/src/components/Tetris/assets/buildPc.js
+++ b/src/components/Tetris/assets/buildPc.js
@@ -75,7 +75,7 @@ const Zblock = {
     color: 'firebrick'
 }
 
-const pcs = [
+const gamePcs = [
     // dummy pieces
     // singlePc,
     // triplePc,
@@ -89,11 +89,26 @@ const pcs = [
     Sblock,
     Tblock,
     Zblock,
+];
 
-]
+const dummyTriPc = {
+    pivot: [1, 1 + startingX],
+    forms: [
+        [ [-1, 0], [1, 0] ],
+        [ [0, -1], [0, 1] ],
+    ],
+    color: 'firebrick'
+};
 
-const buildPc = () => pcs[Math.floor((Math.random() * pcs.length))]
+const dummyPcs = [
+    dummyTriPc
+];
+
+const buildPcFactory = (pcs) => () => pcs[Math.floor((Math.random() * pcs.length))]
 
 export {
-    buildPc
+    buildPcFactory,
+
+    gamePcs,
+    dummyPcs
 }

--- a/src/components/Tetris/assets/buildPc.js
+++ b/src/components/Tetris/assets/buildPc.js
@@ -104,11 +104,11 @@ const dummyPcs = [
     dummyTriPc
 ];
 
-const buildPcFactory = (pcs) => () => pcs[Math.floor((Math.random() * pcs.length))]
+const buildPcFactory = (pcs) => () => pcs[Math.floor((Math.random() * pcs.length))];
 
 export {
     buildPcFactory,
 
     gamePcs,
     dummyPcs
-}
+};

--- a/src/components/Tetris/useTetrisHooks/boardReducer.js
+++ b/src/components/Tetris/useTetrisHooks/boardReducer.js
@@ -6,23 +6,26 @@ import { canHasMovement } from '../assets/canHasMovement';
 import { transformPc } from '../assets/transformPc';
 import { canHasRotation } from '../assets/canHasRotation';
 
-const initBoard = {
-    board: emptyBoard,
-    // pieces
-    activePc: {},
-    /*
-    {pivot[y, x], form, forms[...[]], color}
-    */
+const initBoard = (gamePcs) => { 
+    return {
+        board: emptyBoard,
+        // pieces
+        activePc: {},
+        /*
+        {pivot[y, x], form, forms[...[]], color}
+        */
 
-    inWaitingPc: {},
+        inWaitingPc: {},
 
-    combo: 0,
-    points: 0,
+        combo: 0,
+        points: 0,
 
-    gameActive: false,
-    gamePcs
-};
+        gameActive: false,
+        buildPc: buildPcFactory(gamePcs)
+    };
+}
 
+// constructing while pointing at normal gamePcs
 const buildPc = buildPcFactory(gamePcs);
 
 const BOARD_ACTIONS = {

--- a/src/components/Tetris/useTetrisHooks/boardReducer.js
+++ b/src/components/Tetris/useTetrisHooks/boardReducer.js
@@ -1,7 +1,7 @@
 
 import produce from 'immer';
 import { emptyBoard } from '../assets/emptyBoard.js';
-import { buildPc } from '../assets/buildPc.js';
+import { buildPcFactory, gamePcs } from '../assets/buildPc.js';
 import { canHasMovement } from '../assets/canHasMovement';
 import { transformPc } from '../assets/transformPc';
 import { canHasRotation } from '../assets/canHasRotation';
@@ -20,7 +20,10 @@ const initBoard = {
     points: 0,
 
     gameActive: false,
+    gamePcs
 };
+
+const buildPc = buildPcFactory(gamePcs);
 
 const BOARD_ACTIONS = {
     START: 'start_game',

--- a/src/components/Tetris/useTetrisHooks/index.js
+++ b/src/components/Tetris/useTetrisHooks/index.js
@@ -2,13 +2,22 @@
 import { useTetris } from './useTetris.js'
 import {
     initBoard,
+
     BOARD_ACTIONS,
     boardReducer,
-} from './boardReducer.js'
+} from './boardReducer.js';
+
+import {
+    gamePcs, dummyPcs
+} from '../assets/buildPc';
 
 export {
     useTetris,
     initBoard,
+
+    gamePcs,
+    dummyPcs,
+
     BOARD_ACTIONS,
     boardReducer,
 }


### PR DESCRIPTION
Pieces controlled Tetris

this merge will allow deterministic testing of specific pieces

[] - rebuilds initBoard with a getter factory fetching random pc. this allows me to control Tetris with interchangeable pcs on mount
[] - plugs new component config into main app
[] - plugs new component config into existing tests