### PR TITLE
adds optional configuration for drop interval speed, and tests multip…

### DIFF
--- a/src/components/Tetris/Tetris.js
+++ b/src/components/Tetris/Tetris.js
@@ -39,7 +39,7 @@ const lineActions = {
     'update': BOARD_ACTIONS.UPDATE,
 };
 
-function Tetris({ initBoard }) {
+function Tetris({ initBoard, dropSpeed }) {
 
     const startGameButtonBlurRef = useRef();
     const killActiveButtonBlurRef = useRef();
@@ -49,6 +49,7 @@ function Tetris({ initBoard }) {
     const [boardState, dispatchBoard] = useTetris(boardReducer, initBoard);
     const [dropInt, setDropInt] = useState(null);
 
+    const dropFrequency = dropSpeed || 500;
     // dropInterval
     useEffect(() => {
 
@@ -57,7 +58,7 @@ function Tetris({ initBoard }) {
         setDropInt( setInterval(() => {
 
             dispatchBoard({ type: BOARD_ACTIONS.DOWN });
-        }, 500) );
+        }, dropFrequency) );
 
     } else {
         if (dropInt) {

--- a/src/components/Tetris/__tests__/Tetris[dropInterval].test.jsx
+++ b/src/components/Tetris/__tests__/Tetris[dropInterval].test.jsx
@@ -23,8 +23,14 @@ test('starting tetris should provoke invocations of drop async', async () => {
 
     const before = getPcs(dom_tetris);
 
+    // steps before piece arrives at 2nd last row
+    const steps = 22 - before.activePcsList.reduce((prev, cur) => {
+        if (cur > prev) return cur;
+        return prev;
+    }, 0);
+
     // test for no-drop, and then 15 drops
-    for (let i = 0; i < 16; i++) {
+    for (let i = 0; i < steps+1; i++) {
     // [1] - waitFor dropInterval to pass
         await waitFor(() => {
     // [2] - fetch pcs within async

--- a/src/components/Tetris/__tests__/Tetris[dropInterval].test.jsx
+++ b/src/components/Tetris/__tests__/Tetris[dropInterval].test.jsx
@@ -8,7 +8,7 @@ import { initBoard, gamePcs } from '../useTetrisHooks';
 import { getPcs } from '../../../helpers/spec/getPcs';
 
 beforeEach(() => {
-    render(<Tetris initBoard={initBoard(gamePcs)} />);
+    render(<Tetris initBoard={initBoard(gamePcs)} dropSpeed={1} />);
 });
 
 //=====================
@@ -23,12 +23,16 @@ test('starting tetris should provoke invocations of drop async', async () => {
 
     const before = getPcs(dom_tetris);
 
+    // test for no-drop, and then 15 drops
+    for (let i = 0; i < 16; i++) {
     // [1] - waitFor dropInterval to pass
-    await waitFor(() => {
+        await waitFor(() => {
     // [2] - fetch pcs within async
-        const after = getPcs(dom_tetris);
-        const after_activePcs = after.activePcsList.map(pc => [pc[0]-1, pc[1]]);
+            const after = getPcs(dom_tetris);
+            const after_activePcs = after.activePcsList.map(pc => [pc[0]-i, pc[1]]);
     // [3] - test that active pieces dropped
-        expect(before.activePcsList).toEqual(after_activePcs);
-    });
+            expect(before.activePcsList).toEqual(after_activePcs);
+        });
+    }
+
 });


### PR DESCRIPTION
…le drops

Adds a Speed Configuration Option to the Tetris Component

this is mainly so I can create an environment in which the dropInterval testing is testing the asynchronous incremental changes being made but agnostic to the actual time it takes. pieces should incrementally move downwards, but my test doesn't work so well with or care about the half a second it takes for each drop

[x] - adds optional speed default prop
[x] - rewrites dropInterval test to account for multiple drops